### PR TITLE
SSD1306(OLED driver) : change size of oled_buff[]

### DIFF
--- a/keyboards/helix_ble/ssd1306.c
+++ b/keyboards/helix_ble/ssd1306.c
@@ -38,7 +38,7 @@ static uint16_t last_flush;
 
 static bool force_dirty = true;
 
-uint8_t oled_buff[512];
+uint8_t oled_buff[1 + MatrixRows * DisplayWidth];
 
 // Write command sequence.
 // Returns true on success.


### PR DESCRIPTION
Change the size of oled_buf[] depending on DisplaySize. And fix bug.( buffer over run at oled_buff[] )