### PR TITLE
OLED Support.

### DIFF
--- a/drivers/nrf52/i2c_master.h
+++ b/drivers/nrf52/i2c_master.h
@@ -1,10 +1,7 @@
 #include "nrf/i2c.h"
 #define i2c_stop() i2c_uninit()
 
-// TODO: 本当にこれでいいのか？BMPの戻り値確認
 #define I2C_STATUS_SUCCESS (0)
-#define I2C_STATUS_ERROR (1)
-#define I2C_STATUS_TIMEOUT (2)
 
 #define I2C_TIMEOUT_IMMEDIATE (0)
 #define I2C_TIMEOUT_INFINITE (0xFFFF)

--- a/drivers/nrf52/i2c_master.h
+++ b/drivers/nrf52/i2c_master.h
@@ -1,0 +1,14 @@
+#include "nrf/i2c.h"
+#define i2c_stop() i2c_uninit()
+
+// TODO: 本当にこれでいいのか？BMPの戻り値確認
+#define I2C_STATUS_SUCCESS (0)
+#define I2C_STATUS_ERROR (1)
+#define I2C_STATUS_TIMEOUT (2)
+
+#define I2C_TIMEOUT_IMMEDIATE (0)
+#define I2C_TIMEOUT_INFINITE (0xFFFF)
+
+#ifndef I2C_TIMEOUT
+#  define I2C_TIMEOUT 100
+#endif

--- a/tmk_core/protocol/nrf/i2c.h
+++ b/tmk_core/protocol/nrf/i2c.h
@@ -23,7 +23,7 @@
 #define CONFIG_I2C_ADDR2 0x10
 #endif
 
-static uint8_t i2c_temporary_buffer[4096];
+static uint8_t i2c_temporary_buffer[2048];
 
 static inline int i2c_init(void)
 {

--- a/tmk_core/protocol/nrf/i2c.h
+++ b/tmk_core/protocol/nrf/i2c.h
@@ -1,7 +1,7 @@
 
 #pragma once
 #include <stdint.h>
-
+#include <string.h>
 #include "apidef.h"
 
 #ifndef CONFIG_PIN_SCL
@@ -23,6 +23,8 @@
 #define CONFIG_I2C_ADDR2 0x10
 #endif
 
+static uint8_t i2c_temporary_buffer[4096];
+
 static inline int i2c_init(void)
 {
   const bmp_api_i2cm_config_t config =
@@ -39,24 +41,30 @@ static inline void i2c_uninit(void)
   BMPAPI->i2cm.uninit();
 }
 
-static inline uint8_t i2c_transmit(uint8_t address, uint8_t* data, uint16_t length)
+static inline uint8_t i2c_transmit(uint8_t address, const uint8_t* data, uint16_t length, uint16_t timeout)
 {
-  return BMPAPI->i2cm.transmit(address, data, length);
+  // convert "const uint8_t" to "uint8_t"
+  if(sizeof(i2c_temporary_buffer)/sizeof(i2c_temporary_buffer[0]) < length) return 1;
+  memcpy(i2c_temporary_buffer, data, length);
+  return BMPAPI->i2cm.transmit(address >> 1, (uint8_t*)i2c_temporary_buffer, length);
 }
 
-static inline uint8_t i2c_receive(uint8_t address, uint8_t* data, uint16_t length)
+static inline uint8_t i2c_receive(uint8_t address, uint8_t* data, uint16_t length, uint16_t timeout)
 {
-  return BMPAPI->i2cm.receive(address, data, length);
+  return BMPAPI->i2cm.receive(address >> 1, data, length);
 }
 
 static inline uint8_t i2c_readReg(uint8_t devaddr, uint8_t regaddr, uint8_t* data, uint16_t length, uint16_t timeout)
 {
-  return BMPAPI->i2cm.read_reg(devaddr, regaddr, data, length, timeout);
+  return BMPAPI->i2cm.read_reg(devaddr >> 1, regaddr, data, length, timeout);
 }
 
-static inline uint8_t i2c_writeReg(uint8_t devaddr, uint8_t regaddr, uint8_t* data, uint16_t length, uint16_t timeout)
+static inline uint8_t i2c_writeReg(uint8_t devaddr, uint8_t regaddr, const uint8_t* data, uint16_t length, uint16_t timeout)
 {
-  return BMPAPI->i2cm.write_reg(devaddr, regaddr, data, length, timeout);
+  // convert "const uint8_t" to "uint8_t"
+  if(sizeof(i2c_temporary_buffer)/sizeof(i2c_temporary_buffer[0]) < length) return 1;
+  memcpy(i2c_temporary_buffer, data, length);
+  return BMPAPI->i2cm.write_reg(devaddr >> 1, regaddr, (uint8_t*)i2c_temporary_buffer, length, timeout);
 }
 
 


### PR DESCRIPTION
### 変更
* i2c.hにある関数を他(avr,arm系)と共通化
* * i2c_transmit/i2c_receive引数にtimeoutを追加
* * 左揃えのaddressが入ってくる前提に変更
* * write系(i2c_transmit / i2c_writeReg)関数の引数"uint8_t *data"をconst化
* oled_driverが使用可能に
* * キーボードのrules.mkに OLED_DRIVER_ENABLE = yes を追加でoled系関数が使えるようになりました。
* * 詳細は https://beta.docs.qmk.fm/features/feature_oled_driver

### 気になってる所
* const uint8_t→uint8_t 変換をするために、2kバッファを確保していますがあまり好ましくありません。
* * これはconst uint8_t* dataをキャストしてi2cm.transmit()が正常に動作しなかったためです
* * BMPAPIもconstになる予定なんてありますか・・・？
```
static uint8_t i2c_temporary_buffer[2048];

static inline uint8_t i2c_transmit(uint8_t address, const uint8_t* data, uint16_t length, uint16_t timeout)
{
  // convert "const uint8_t" to "uint8_t"
  if(sizeof(i2c_temporary_buffer)/sizeof(i2c_temporary_buffer[0]) < length) return 1;
  memcpy(i2c_temporary_buffer, data, length);
  return BMPAPI->i2cm.transmit(address >> 1, (uint8_t*)i2c_temporary_buffer, length);
}
```

