### PR TITLE
restart_advertising_id: Prevent use of illegal ID

### DIFF
--- a/tmk_core/protocol/nrf/sdk12/ble_master.c
+++ b/tmk_core/protocol/nrf/sdk12/ble_master.c
@@ -1380,7 +1380,7 @@ void restart_advertising_id(uint8_t id) {
   m_whitelist_peer_cnt = (sizeof(m_whitelist_peers) / sizeof(pm_peer_id_t));
 
   peer_list_get(m_whitelist_peers, &m_whitelist_peer_cnt);
-  if (id > m_whitelist_peer_cnt) {
+  if (id >= m_whitelist_peer_cnt) {
     return;
   }
   m_whitelist_peer_cnt = 1;

--- a/tmk_core/protocol/nrf/sdk15/ble_master.c
+++ b/tmk_core/protocol/nrf/sdk15/ble_master.c
@@ -1305,10 +1305,13 @@ void restart_advertising_id(uint8_t id) {
   m_whitelist_peer_cnt = (sizeof(m_whitelist_peers) / sizeof(pm_peer_id_t));
 
   peer_list_get(m_whitelist_peers, &m_whitelist_peer_cnt);
-  if (id > m_whitelist_peer_cnt) {
+  if (id >= m_whitelist_peer_cnt) {
     return;
   }
 #ifdef NRF_SEPARATE_KEYBOARD_MASTER
+  if (id == 0) {
+    return;
+  }
   m_whitelist_peer_cnt = 2;
   m_whitelist_peers[1] = m_whitelist_peers[id];
 #else


### PR DESCRIPTION

## Description

* Fix crash when given an ID one greater than permitted.

* For split keyboards, ID 0 is reserved for slave, so make ADV_ID0 a no-op.

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
