### PR TITLE
keyboard LEDS && adafruit bootloader soft jump

### DIFF
--- a/tmk_core/common/nrf/bootloader.c
+++ b/tmk_core/common/nrf/bootloader.c
@@ -2,13 +2,21 @@
 #include "nrf.h"
 #include "nrf_power.h"
 
+#ifdef BOOTLOADER_METHOD_ADAFUIT_UF2
+#define DFU_MAGIC_UF2_RESET 0x57 // https://github.com/adafruit/Adafruit_nRF52_Bootloader/blob/master/src/main.c
+#define BOOTLOADER_GPREGRET DFU_MAGIC_UF2_RESET
+#else
+#define BOOTLOADER_GPREGRET 1
+#endif
+
 __attribute__((weak))
 void bootloader_jump(void) {
 #if NRF_SDK_MAJOR_VER==15
-  sd_power_gpregret_set(0, 1);
+  sd_power_gpregret_clr(0, 0xFFFFFFFF);
+  sd_power_gpregret_set(0, BOOTLOADER_GPREGRET);
   NVIC_SystemReset();
 #elif NRF_SDK_MAJOR_VER==12
-  NRF_POWER->GPREGRET |= 1;
+  NRF_POWER->GPREGRET |= BOOTLOADER_GPREGRET;
   NVIC_SystemReset();
 #else
 #error "Invalid nRF_SDK version."

--- a/tmk_core/protocol/nrf/sdk15/usbd.c
+++ b/tmk_core/protocol/nrf/sdk15/usbd.c
@@ -567,13 +567,16 @@ char cdc_acm_getc() {
 //static void kbd_action(uint32_t button_state) {
 //}
 //
+
+extern uint16_t keyboard_led_stats;
 static void kbd_status(void) {
-//    bool v;
-//    v = app_usbd_hid_kbd_led_state_get(&m_app_hid_kbd, APP_USBD_HID_KBD_LED_NUM_LOCK);
-//    v ? bsp_board_led_on(LED_HID_REP_IN) : bsp_board_led_off(LED_HID_REP_IN);
-//
-//    v = app_usbd_hid_kbd_led_state_get(&m_app_hid_kbd, APP_USBD_HID_KBD_LED_CAPS_LOCK);
-//    v ? bsp_board_led_on(LED_HID_REP_OUT) : bsp_board_led_off(LED_HID_REP_OUT);
+	uint8_t led=0;
+	led += app_usbd_hid_kbd_led_state_get(&m_app_hid_kbd, APP_USBD_HID_KBD_LED_NUM_LOCK) ? APP_USBD_HID_KBD_LED_NUM_LOCK : 0;
+	led += app_usbd_hid_kbd_led_state_get(&m_app_hid_kbd, APP_USBD_HID_KBD_LED_CAPS_LOCK) ? APP_USBD_HID_KBD_LED_CAPS_LOCK : 0;
+	led += app_usbd_hid_kbd_led_state_get(&m_app_hid_kbd, APP_USBD_HID_KBD_LED_SCROLL_LOCK) ? APP_USBD_HID_KBD_LED_SCROLL_LOCK : 0;
+	led += app_usbd_hid_kbd_led_state_get(&m_app_hid_kbd, APP_USBD_HID_KBD_LED_COMPOSE) ? APP_USBD_HID_KBD_LED_COMPOSE : 0;
+	led += app_usbd_hid_kbd_led_state_get(&m_app_hid_kbd, APP_USBD_HID_KBD_LED_KANA) ? APP_USBD_HID_KBD_LED_KANA : 0;
+    keyboard_led_stats = led;
 }
 
 

--- a/tmk_core/protocol/nrf/usbd.h
+++ b/tmk_core/protocol/nrf/usbd.h
@@ -4,14 +4,14 @@
 #include "host.h"
 #if defined(NRF52840_XXAA) && NRF_SDK_MAJOR_VER==15
 int usbd_init(void);
-void usbd_enable(void);
-int usbd_process(void);
+int usbd_enable(void);
+void usbd_process(void);
 int usbd_send_keyboard(report_keyboard_t *report);
 int usbd_send_mouse(report_mouse_t *report);
 int usbd_send_system(uint16_t data);
 int usbd_send_consumer(uint16_t data);
-int usbd_send_abs_mouse(uint8_t x, uint8_t y);
-int usbd_send_cdc_acm(uint8_t *dat, uint8_t cnt);
+int usbd_send_abs_mouse(int8_t x, int8_t y);
+void usbd_send_cdc_acm(uint8_t *dat, uint8_t cnt);
 
 // Functions for CLI
 int cdc_acm_byte_to_read();
@@ -20,13 +20,13 @@ char cdc_acm_getc();
 
 #else
 int usbd_init(void) {return 0;}
-void usbd_enable(void) {}
-int usbd_process(void) {return 0;}
+int usbd_enable(void) {}
+void usbd_process(void) {return 0;}
 int usbd_send_keyboard(report_keyboard_t *report) {return 0;}
 int usbd_send_mouse(report_mouse_t *report) {return 0;}
 int usbd_send_system(uint16_t data) {return 0;}
 int usbd_send_consumer(uint16_t data) {return 0;}
-int usbd_send_abs_mouse(uint8_t x, uint8_t y) {return 0;}
+int usbd_send_abs_mouse(int8_t x, int8_t y) {return 0;}
 #endif /* NRF82400_XXAA */
 
 #endif /* TMK_CORE_PROTOCOL_NRF_NRF52_USBD_H_ */

--- a/tmk_core/protocol/nrf/usbd.h
+++ b/tmk_core/protocol/nrf/usbd.h
@@ -20,8 +20,8 @@ char cdc_acm_getc();
 
 #else
 int usbd_init(void) {return 0;}
-int usbd_enable(void) {}
-void usbd_process(void) {return 0;}
+int usbd_enable(void) {return 0;}
+void usbd_process(void) {}
 int usbd_send_keyboard(report_keyboard_t *report) {return 0;}
 int usbd_send_mouse(report_mouse_t *report) {return 0;}
 int usbd_send_system(uint16_t data) {return 0;}


### PR DESCRIPTION
## Description

- Fix USB & BLE HID Output report (keyboard LEDS)
- Add Adafruit nrf52 bootloader jump condition for DFU UF2 mode

## Types of Changes

- [ ] Core
- [X] Bugfix
- [X] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

- Keyboards LED not work as expected nor in USB niether in BLE mode. Now it just need to define `led_set_user(uint8_t usb_led)`
- Call of `bootloader_jump()` don't work on some specific bootloaders - they need their's specific "boot" conditions.

## Checklist

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [X] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
