### PR TITLE
Use SERIAL_NUMBER environment variable to .iSerialNumber

### DIFF
--- a/keyboards/keyboard_quantizer/config.h
+++ b/keyboards/keyboard_quantizer/config.h
@@ -26,6 +26,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define DEVICE_VER      0x0001
 #define MANUFACTURER    sekigon-gonnoc
 #define PRODUCT         Keyboard Quantizer
+#ifndef SERIAL_NUMBER
+#define SERIAL_NUMBER   123456
+#endif
 #define DESCRIPTION     Quantize your keyboard
 
 #define TAPPING_TERM_PER_KEY

--- a/keyboards/keyboard_quantizer/rules.mk
+++ b/keyboards/keyboard_quantizer/rules.mk
@@ -28,3 +28,9 @@ BLUETOOTH_ENABLE = no       # Enable Bluetooth with the Adafruit EZ-Key HID
 AUDIO_ENABLE = no           # Audio output on port C6
 FAUXCLICKY_ENABLE = no      # Use buzzer to emulate clicky switches
 HD44780_ENABLE = no 		# Enable support for HD44780 based LCDs (+400)
+
+ifeq ($(strip ${SERIAL_NUMBER}),)
+#	Use default SERIAL_NUMBER (123456)
+else
+	OPT_DEFS += -DSERIAL_NUMBER="${SERIAL_NUMBER}"
+endif

--- a/tmk_core/protocol/pico/usb_descriptors.c
+++ b/tmk_core/protocol/pico/usb_descriptors.c
@@ -184,9 +184,9 @@ uint8_t const* tud_descriptor_configuration_cb(uint8_t index) {
 // array of pointer to string descriptors
 char const* string_desc_arr[] = {
     (const char[]){0x09, 0x04},  // 0: is supported language is English (0x0409)
-    STR(MANUFACTURER),          // 1: Manufacturer
-    STR(PRODUCT),               // 2: Product
-    "123456",                    // 3: Serials, should use chip ID
+    STR(MANUFACTURER),           // 1: Manufacturer
+    STR(PRODUCT),                // 2: Product
+    STR(SERIAL_NUMBER),          // 3: Serials, should use chip ID
 };
 
 static uint16_t _desc_str[32];


### PR DESCRIPTION
Allow device serial number to be set from `SERIAL_NUMBER` environment variable.

We can include the git object name into serial number as follows.

```shell
SERIAL_NUMBER=$(git rev-parse --short HEAD) make keyboard_quantizer/rp:default:uf2
```
