### PR TITLE
Fix for debug output in matrix_scan

### DIFF
--- a/tmk_core/protocol/nrf/matrix.c
+++ b/tmk_core/protocol/nrf/matrix.c
@@ -155,10 +155,10 @@ __attribute__((weak)) uint8_t matrix_scan_impl(matrix_row_t *_matrix) {
     if (debug_config.keyboard && matrix_changed > 0) {
         dprintf("device rows:\n");
         for (uint8_t idx = 0; idx < device_row; idx++) {
-            if (config->matrix.cols <= 8) {
+            if (device_col <= 8) {
                 dprintf("\tdr%02d:0x%02x\n", idx,
                         matrix_debouncing[idx + matrix_offset]);
-            } else if (config->matrix.cols <= 16) {
+            } else if (device_col <= 16) {
                 dprintf("\tdr%02d:0x%04x\n", idx,
                         matrix_debouncing[idx + matrix_offset]);
             } else {
@@ -183,10 +183,10 @@ __attribute__((weak)) uint8_t matrix_scan_impl(matrix_row_t *_matrix) {
 
     if (debug_config.keyboard && pop_cnt > 0) {
         dprintf("matrix rows:\n");
-        for (uint8_t idx = 0; idx < device_row; idx++) {
-            if (device_col <= 8) {
+        for (uint8_t idx = 0; idx < config->matrix.rows; idx++) {
+            if (config->matrix.cols <= 8) {
                 dprintf("\tr%02d:0x%02x\n", idx, _matrix[idx]);
-            } else if (device_col <= 16) {
+            } else if (config->matrix.cols <= 16) {
                 dprintf("\tr%02d:0x%04x\n", idx, _matrix[idx]);
             } else {
                 dprintf("\tr%02d:0x%08x\n", idx, _matrix[idx]);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

## Description

Fix for debug output in matrix_scan.

Confirmed with corne cherry keyboard which has {"rows":8,"cols":6,"device_rows":4,"device_cols":6}.
I think this keyboard should display 8 rows as matrix.

before this fix:

```
[2023-09-01 22:01:15.872] ---- action_exec: start -----
[2023-09-01 22:01:15.872] EVENT: 0500u(31961)
[2023-09-01 22:01:15.872] Process KC:40
[2023-09-01 22:01:15.872] ACTION: ACT_LMODS[0:28] layer_state: 00000004(2) default_layer_state: 00000000(0)
[2023-09-01 22:01:15.875] keyboard_report: 00 00 00 00 00 00 00 00 
[2023-09-01 22:01:15.875] processed: 0500u(31961):0 
[2023-09-01 22:01:15.875] 
[2023-09-01 22:01:15.906] matrix rows:
[2023-09-01 22:01:15.908] 	r00:0x00
[2023-09-01 22:01:15.908] 	r01:0x00
[2023-09-01 22:01:15.908] 	r02:0x00
[2023-09-01 22:01:15.908] 	r03:0x00
[2023-09-01 22:01:15.908] 
[2023-09-01 22:01:15.908] 
[2023-09-01 22:01:15.908] ---- action_exec: start -----
[2023-09-01 22:01:15.908] EVENT: 0705u(31995)
[2023-09-01 22:01:15.908] Process KC:20738
[2023-09-01 22:01:15.908] ACTION: ACT_LAYER_TAP[2:F1] layer_state: 00000004(2) default_layer_state: 00000000(0)
[2023-09-01 22:01:15.908] layer_state: 00000004(2) to 00000000(0)
[2023-09-01 22:01:15.908] keyboard_report: 00 00 00 00 00 00 00 00 
[2023-09-01 22:01:15.908] processed: 0705u(31995):0 
[2023-09-01 22:01:15.911] 
[2023-09-01 22:01:16.630] device rows:
[2023-09-01 22:01:16.636] 	dr00:0x00
[2023-09-01 22:01:16.636] 	dr01:0x02
[2023-09-01 22:01:16.636] 	dr02:0x00
[2023-09-01 22:01:16.636] 	dr03:0x00
[2023-09-01 22:01:16.636] 
[2023-09-01 22:01:16.681] matrix rows:
[2023-09-01 22:01:16.691] 	r00:0x00
[2023-09-01 22:01:16.691] 	r01:0x02
[2023-09-01 22:01:16.691] 	r02:0x00
[2023-09-01 22:01:16.691] 	r03:0x00
```

after this fix:

```
k[2023-09-01 22:06:23.392] bmp@Corne>version
[2023-09-01 22:06:28.284] version:
[2023-09-01 22:06:28.284] UF2 Bootloader v0.11.2-0-g5c8d630
[2023-09-01 22:06:28.284] Model: BLE Micro Pro
[2023-09-01 22:06:28.284] Board-ID: NRF52840-BMP-V1
[2023-09-01 22:06:28.284] API version: 13
[2023-09-01 22:06:28.284] Config version: 2
[2023-09-01 22:06:28.284] 
[2023-09-01 22:06:28.284] app:
[2023-09-01 22:06:28.284] API version: 13
[2023-09-01 22:06:28.284] Config version: 2
[2023-09-01 22:06:28.284] Build from: bmp-0.11.3-7-g2b2aa64b5b
[2023-09-01 22:06:28.284] Build Target: ble_micro_pro_default
[2023-09-01 22:06:28.284] bmp@Corne>debug keyboard
[2023-09-01 22:06:35.068] bmp@Corne>matrix rows:
[2023-09-01 22:06:35.115] 	r00:0x00
[2023-09-01 22:06:35.115] 	r01:0x00
[2023-09-01 22:06:35.115] 	r02:0x00
[2023-09-01 22:06:35.115] 	r03:0x00
[2023-09-01 22:06:35.115] 	r04:0x00
[2023-09-01 22:06:35.115] 	r05:0x00
[2023-09-01 22:06:35.115] 	r06:0x00
[2023-09-01 22:06:35.115] 	r07:0x20
[2023-09-01 22:06:35.115] 
[2023-09-01 22:06:35.115] 
[2023-09-01 22:06:35.115] ---- action_exec: start -----
[2023-09-01 22:06:35.115] EVENT: 0500u(27813)
[2023-09-01 22:06:35.115] Process KC:40
[2023-09-01 22:06:35.115] ACTION: ACT_LMODS[0:28] layer_state: 00000004(2) default_layer_state: 00000000(0)
[2023-09-01 22:06:35.115] keyboard_report: 00 00 00 00 00 00 00 00 
[2023-09-01 22:06:35.115] processed: 0500u(27813):0 
[2023-09-01 22:06:35.115] 
[2023-09-01 22:06:35.130] matrix rows:
[2023-09-01 22:06:35.132] 	r00:0x00
[2023-09-01 22:06:35.132] 	r01:0x00
[2023-09-01 22:06:35.132] 	r02:0x00
[2023-09-01 22:06:35.132] 	r03:0x00
[2023-09-01 22:06:35.132] 	r04:0x00
[2023-09-01 22:06:35.132] 	r05:0x00
[2023-09-01 22:06:35.132] 	r06:0x00
[2023-09-01 22:06:35.132] 	r07:0x00
[2023-09-01 22:06:35.132] 
[2023-09-01 22:06:35.132] 
[2023-09-01 22:06:35.132] ---- action_exec: start -----
[2023-09-01 22:06:35.132] EVENT: 0705u(27829)
[2023-09-01 22:06:35.132] Process KC:20738
[2023-09-01 22:06:35.132] ACTION: ACT_LAYER_TAP[2:F1] layer_state: 00000004(2) default_layer_state: 00000000(0)
[2023-09-01 22:06:35.132] layer_state: 00000004(2) to 00000000(0)
[2023-09-01 22:06:35.132] keyboard_report: 00 00 00 00 00 00 00 00 
[2023-09-01 22:06:35.134] processed: 0705u(27829):0 
[2023-09-01 22:06:35.134] 
[2023-09-01 22:06:37.785] device rows:
[2023-09-01 22:06:37.787] 	dr00:0x00
[2023-09-01 22:06:37.787] 	dr01:0x02
[2023-09-01 22:06:37.787] 	dr02:0x00
[2023-09-01 22:06:37.787] 	dr03:0x00
[2023-09-01 22:06:37.787] 
[2023-09-01 22:06:37.836] matrix rows:
[2023-09-01 22:06:37.837] 	r00:0x00
[2023-09-01 22:06:37.837] 	r01:0x02
[2023-09-01 22:06:37.837] 	r02:0x00
[2023-09-01 22:06:37.837] 	r03:0x00
[2023-09-01 22:06:37.837] 	r04:0x00
[2023-09-01 22:06:37.837] 	r05:0x00
[2023-09-01 22:06:37.837] 	r06:0x00
[2023-09-01 22:06:37.837] 	r07:0x00
```


<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->


<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* (none)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
